### PR TITLE
Исправление avgSize_BookPart для книг, содержащих раздел "Информация"

### DIFF
--- a/klavotools.json
+++ b/klavotools.json
@@ -619,7 +619,7 @@
   },
   {
     "name": "avgSize_BookPart",
-    "version": "1.1.0+kts",
+    "version": "1.1.1+kts",
     "authors": [
       "Lexin13"
     ],

--- a/scripts/avgSize_BookPart.user.js
+++ b/scripts/avgSize_BookPart.user.js
@@ -1,7 +1,7 @@
 // ==UserScript== 
 // @name           avgSize_BookPart
 // @namespace      klavogonki
-// @version        1.1.0+kts
+// @version        1.1.1+kts
 // @include        http://klavogonki.ru/vocs/*
 // @author         Lexin13
 // @description    Показывает для словарей-книг примерное количество символов на отрывок
@@ -48,7 +48,15 @@ if(!document.getElementById('KTS_avgSize_BookPart')) {
 	}
 	else
 	{
-	    var content = document.getElementsByClassName("user-content")[0].getElementsByTagName("dd")[6]; 
+	    var userContent = document.getElementsByClassName("user-content")[0];
+	    if (userContent === undefined)
+	        return;
+
+	    var titles = userContent.getElementsByTagName("dt");
+	    for (var i = 0; i < titles.length; i++)
+	        if (titles[i].innerHTML.indexOf("Содержание:") != -1)
+	            var content = userContent.getElementsByTagName("dd")[i];
+
 	    var textPos = content.innerHTML.indexOf("<div"); 
 	    var stat = content.innerHTML.substr(0, textPos).trim(); 
 


### PR DESCRIPTION
Текущий код скрипта содержит хардкод на номер раздела ("Содержание"), в котором находится информация о числе отрывков и символов в книге. Однако номер меняется в зависимости от следующих условий:
1) содержит ли книга раздел "Информация" или нет;
2) добавлена ли книга самим пользователем или другим  (если добавил сам, то пропадает раздел "Ваша оценка");
3) залогинен ли пользователь или нет (если не залогинен, то не будет раздела "Ваша оценка")

Изначально хотел просто брать последний элемент массива. Однако, если книга добавлена самим пользователем, тот этот способ не работает, т.к. последними идут кнопки "Редактировать"/"Удалить". Поэтому добавил небольшой поиск через парсинг имен разделов.

По поводу проверки на undefined. У меня при тестировании в tampermonkey в firefox developer edition (73) судя по консоли получалось, что скрипт выполняется дважды (когда не был залогинен на сайт). Второй раз с ошибкой. Я так понял, что это из-за iframe или чего-то подобного. Нашел еще решение с доп. проверкой, что если window.top != window.self, то не выполнять скрипт, но не знаю что здесь подойдет лучше.