### PR TITLE
Mark BigTextArea and KG_YandexTranslator as broken

### DIFF
--- a/klavotools.json
+++ b/klavotools.json
@@ -490,6 +490,7 @@
   },
   {
     "name": "KG_YandexTranslator",
+    "broken": true,
     "version": "0.2.1",
     "authors": [
       "agile"

--- a/klavotools.json
+++ b/klavotools.json
@@ -14,11 +14,12 @@
   },
   {
     "name": "BigTextArea",
+    "broken": true,
+    "disabled": true,
     "version": "1.1.0+kts",
     "authors": [
       "Fenex"
     ],
-    "integrated": true,
     "tags": [
       "Форум"
     ],


### PR DESCRIPTION
**BigTextArea** уже обсуждали ранее - скрипт древний, нужность сомнительная. Особенно учитывая, что кнопки только мешаются лишние, а размер поля можно и так регулировать при необходимости. Более того, кнопки сломаны в настоящее время и чинить их смысла особого нет. Пометил как сломанный и удалил из стандартного набора. Если окажется, что он кому-то действительно нужен, то можно будет вернуть, удалив функционал кнопок.

**KG_YandexTranslator** - по всей видимости тоже сломан. Да и было бы странно, если бы работал. Чинить смысла тоже особого нет, учитывая различные ограничения Яндекс на число переводов за определенный интервал времени и проч. Пометил как сломанный.
