### PR TITLE
Возвращает Провал для кирилицу а для английского языка Fail.

### DIFF
--- a/klavotools.json
+++ b/klavotools.json
@@ -116,7 +116,7 @@
   },
   {
     "name": "KG_StopErrorsRace",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "authors": [
       "Akmat"
     ],

--- a/scripts/KG_StopErrorsRace.user.js
+++ b/scripts/KG_StopErrorsRace.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         KG_StopErrorsRace
 // @namespace    klavogonki
-// @version      1.2.0
+// @version      1.3.0
 // @description  Останавливает заезд и создает новый если количество ошибок больше, чем указанное в настройках.
 // @author       Akmat
 // @include      http*://klavogonki.ru/g/*
@@ -127,9 +127,26 @@ function createNewGameAndRedirect() {
 	window.location = `/g/${url}.replay`;
 }
 
+function getFailWord() {
+	const someWords = document.getElementById('afterfocus').innerText;
+	let res = 0;
+
+	someWords.split('').forEach(item => {
+		if (item.charCodeAt() >= 65 && item.charCodeAt() <= 122) {
+			res++;
+		}
+	});
+	
+    if (res >= 40) {
+		return 'Fail';
+	} else {
+		return 'Провал';
+	}
+}
+
 function creatFailWord() {
     const p = document.createElement("p");
-    p.innerText = 'Провал';
+    p.innerText = getFailWord();
     p.setAttribute( 'class', 'stop-error-fail');
     
     if (document.getElementsByClassName('stop-error-fail').length === 0) {


### PR DESCRIPTION
Когда набираем тект скрипт проверяет набираемый текст. Если набираемый тект на кирилице то когда мы превыщаем лимит ошибок мы получаем слово Провал когда остановится игра.
Иначе мы получаем слово Fail.

Почему эту проблему решил так.
Не знаю почему так получается. Когда использую регулярные выражения `\w+`. `/\w/.test(string)` получаю `true`.
Есть текст на русском: " беcпoдобные! Сразу пришли на ум таверны далекой Ямайки, шум заокеанских портов, свежие ветры странствий. Моряк был с понятием, вещи любил отменные! Несколько перламутровых раковин-пепельниц были просто великолепны. Кирилл поднес одну из них к уху, прислушался."

И когда проверяю на наличие английских букв `\w+` на сайте regex101.com нашел буквы английского алфавита: c и o.
Получается мы не можем сказать 100% тов что текст на русском не содержить английские буквы.
По этому решил таким образом. Если в тексте больше английских букв чем 40(примерно) считаю это английский словарь.
Иначе русский словарь.